### PR TITLE
Closes #60

### DIFF
--- a/browser/js/common/services/graph.service.js
+++ b/browser/js/common/services/graph.service.js
@@ -8,22 +8,25 @@
 *
 */
 
-app.service('GraphService', function (DashboardFactory) {
+app.service('GraphService', function(DashboardFactory) {
     var self = this;
     var ndx, myData;
+    //Object to store all instances of chart to resize/edit specific chart
+    var charts = {};
 
     this.create = function(id, chartType, xAxis, yAxis, groupType) {
 
         var chartContainer = $('#widget-container-' + id + '> .box-content > .widget-content-container')[0];
         var chartWidth = chartContainer.offsetWidth;
         var chartHeight = chartContainer.offsetHeight;
-        var chartRadius = chartWidth < chartHeight ? chartWidth/2 : chartHeight/2;
+        var chartRadius = chartWidth < chartHeight ? chartWidth / 2 : chartHeight / 2;
         console.log(chartWidth, chartHeight, chartRadius);
         ///var all = ndx.groupAll()
 
         var dim = ndx.dimension(function(d) {
             return d[xAxis];
         })
+
 
         var grp = dim.group().reduceSum(function(d) {
             return d[yAxis];
@@ -36,52 +39,71 @@ app.service('GraphService', function (DashboardFactory) {
         //var chart = dc[chartType](chartContainer);
         var chart = dc[chartType]('#widget-container-' + id + '> .box-content > .widget-content-container');
 
+        //Add chart to Dictionart with a reference to the chart, and it's specific type (pie,bar,etc)
+        //Is there a way to find out what kind of chart it is by checking the instance itself?
+        charts['chart' + id] = {
+            chart: chart,
+            chartType: chartType
+        };
+
         if (chartType === "pieChart") {
             chart
                 .width(chartWidth)
                 .height(chartHeight)
-                .radius((chartWidth < chartHeight ? chartWidth/2 : chartHeight/2)*.8)
-                .innerRadius(chartWidth/6)
+                .radius((chartWidth < chartHeight ? chartWidth / 2 : chartHeight / 2) * .8)
+                .innerRadius(chartWidth / 6)
                 .dimension(dim)
                 .group(grp)
         } else if (chartType === "barChart") {
+            //margins prevents axes labels from being cutoff
             chart
                 .width(chartWidth)
                 .height(chartHeight * .8)
                 .margins({
                     top: 10,
                     right: 10,
-                    bottom: 10,
-                    left: 10
+                    bottom: 20,
+                    left: 20
                 })
                 .dimension(dim)
                 .group(grp)
                 .elasticY(true)
-                .centerBar(true)
+                .centerBar(false)
                 .x(d3.scale.ordinal())
                 .xUnits(dc.units.ordinal)
                 .renderHorizontalGridLines(true)
         }
-
-        // chart.xAxis().tickFormat(
-        //     function(v) {
-        //         return v + '%';
-        //     });
-        // chart.yAxis().ticks(5);
         dc.renderAll();
     };
 
-    this.resize = function(){
+    this.resize = function(id) {
         //http://plnkr.co/edit/kJDKH0?p=preview
         var chartContainer = $('#widget-container-' + id + '> .box-content > .widget-content-container')[0];
         var chartWidth = chartContainer.offsetWidth;
-          // var newWidth = document.getElementById('box-test').offsetWidth;
-          // chart.width(newWidth)
-          //   .transitionDuration(0);
-          // pie.transitionDuration(0);
-          // dc.renderAll();
-          // chart.transitionDuration(750);
-          // pie.transitionDuration(750);
+        var chartHeight = chartContainer.offsetHeight;
+        var chartRadius = chartWidth < chartHeight ? chartWidth / 2 : chartHeight / 2;
+        // var newWidth = document.getElementById('box-test').offsetWidth;
+        // chart.width(newWidth)
+        //   .transitionDuration(0);
+        // pie.transitionDuration(0);
+        // dc.renderAll();
+        // chart.transitionDuration(750);
+        // pie.transitionDuration(750);
+
+        var chartObj = charts["chart" + id]
+        var chart = chartObj.chart;
+
+        if (chartObj.chartType === "pieChart") {
+            chart
+                .radius(chartRadius * .8)
+                .innerRadius(chartRadius / 3)
+        } else if (chartObj.chartType === "barChart") {
+            chart
+                .width(chartWidth * .8)
+                .height(chartHeight * .8)
+        }
+
+        dc.renderAll();
     }
 
     //load data

--- a/browser/js/dashboard/dashboard.controller.js
+++ b/browser/js/dashboard/dashboard.controller.js
@@ -10,7 +10,10 @@ app.controller('DashboardCtrl', function ($scope, $timeout, GraphService){
             enabled: false
         },
         resizable:{
-            enabled: false
+            enabled: false,
+            stop: function(a,b,c){  //On resize stop, this call back fires (relabel a,b,c)
+                GraphService.resize(c.id);
+            }
             //handles: ['n', 'e', 's', 'w', 'se', 'sw']
         },
         maxSizeX: 6, // maximum column width of an item

--- a/browser/js/home/home.js
+++ b/browser/js/home/home.js
@@ -165,7 +165,7 @@ app.controller('HomeCtrl', function($scope) {
                 .dimension(userDimension)
                 .group(userGroup)
                 .elasticY(true)
-                .centerBar(true)
+                .centerBar(false)
                 .x(d3.scale.ordinal())
                 .xUnits(dc.units.ordinal)
                 .renderHorizontalGridLines(true)

--- a/browser/scss/dashboard/widget.scss
+++ b/browser/scss/dashboard/widget.scss
@@ -9,3 +9,8 @@
     width:100%;
     height:100%;
 }
+
+.dc-chart {
+	text-align: center;
+	overflow: hidden;
+}

--- a/server/app/views/index.html
+++ b/server/app/views/index.html
@@ -4,6 +4,7 @@
 <head>
     <base href="/" />
     <title>Fullstack Academy Generated Application</title>
+    <link rel="stylesheet" href="/angular-gridster/dist/angular-gridster.min.css"/>
     <link rel="stylesheet" type="text/css" href="/dc/dc.min.css" />
     <link rel="stylesheet" type="text/css" href="/angular-gridster/dist/angular-gridster.min.css"/>
     <link rel="stylesheet" type="text/css" href="/bootstrap/dist/css/bootstrap.css" />


### PR DESCRIPTION
Resizing is working in this pull, issues that still need to be resolved are:

Gridster gets resized to preset increments, so if you drag the grid outside of one of these increments the chart will get resized to fit the initial size of the widget, and then the widget will resize to the final size, and the chart will not fit correctly any more.

Pie chart isn't sizing very well, svg element is much bigger than pie chart in some cases